### PR TITLE
feat: take into account the analyzer's score.final when sorting suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ queries.search.suggestions('gulp', esClient)
 Available options:
 
 - `size`: The total number of results to return, defaults to `25`
+- `analyzerWeight`: How much should we weight the analyzer's `score.final` by? defaults to `1.0`.
+- `scoreWeight`: How much should we weight the search `_score`? defaults to `0.3`.
 
 #### .search.similar(q, esClient, [options]) -> Promise
 
@@ -92,8 +94,8 @@ queries.search.similar('chaik', esClient)
 Available options:
 
 - `size`: The total number of results to return, defaults to `10`.
-- `analyzerWeight`: How much should we weight the analyzer values by? defaults to `2.2`.
-- `scoreWeight`: How much should we weight the fuzzy score by? defaults to `1.5`.
+- `analyzerWeight`: How much should we weight the analyzer's `score.final` by? defaults to `2.2`.
+- `scoreWeight`: How much should we weight the search `_score`? defaults to `1.5`.
 - `minScore`: defaults to `4.5`.
 
 _the above default values were based on trial and error examining the

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Available options:
 - `size`: The total number of results to return, defaults to `10`.
 - `analyzerWeight`: How much should we weight the analyzer's `score.final` by? defaults to `2.2`.
 - `scoreWeight`: How much should we weight the search `_score`? defaults to `1.5`.
+- `boostExact`: How much should the score of exact matches be boosted? defaults to `100000`.
 - `minScore`: defaults to `4.5`.
 
 _the above default values were based on trial and error examining the

--- a/lib/searchSuggestions.js
+++ b/lib/searchSuggestions.js
@@ -6,9 +6,14 @@ const toEsClient = require('./util/toEsClient');
 
 function searchSuggestions(q, esClient, options) {
     esClient = toEsClient(esClient);
-    options = Object.assign({ size: 25 }, options);
+    options = Object.assign({
+      size: 25,
+      analyzerWeight: 1,
+      scoreWeight: 0.3
+    }, options);
 
     const text = parseQuery.discardQualifiers(q);
+    const script = `(doc["score.final"].value * ${options.analyzerWeight}) * (_score * ${options.scoreWeight})`;
 
     if (!text) {
         return Promise.resolve([]);
@@ -77,8 +82,7 @@ function searchSuggestions(q, esClient, options) {
                     },
                     script_score: {
                         lang: 'groovy',
-                        script: 'doc["package.name.raw"].value.equals(text) ? 100000 + _score : _score',
-                        params: { text },
+                        script: script
                     },
                 },
             },

--- a/lib/searchSuggestions.js
+++ b/lib/searchSuggestions.js
@@ -9,11 +9,12 @@ function searchSuggestions(q, esClient, options) {
     options = Object.assign({
       size: 25,
       analyzerWeight: 1,
-      scoreWeight: 0.3
+      scoreWeight: 0.3,
+      boostExact: 100000
     }, options);
 
     const text = parseQuery.discardQualifiers(q);
-    const script = `(doc["score.final"].value * ${options.analyzerWeight}) * (_score * ${options.scoreWeight})`;
+    const script = `(doc["score.final"].value * ${options.analyzerWeight}) * (_score * ${options.scoreWeight}) + doc[\"package.name.raw\"].value.equals(text) ? ${options.boostExact} : 0`;
 
     if (!text) {
         return Promise.resolve([]);
@@ -82,7 +83,8 @@ function searchSuggestions(q, esClient, options) {
                     },
                     script_score: {
                         lang: 'groovy',
-                        script: script
+                        script: script,
+                        params: { text }
                     },
                 },
             },

--- a/test/fixtures/search-suggestions-sass.json
+++ b/test/fixtures/search-suggestions-sass.json
@@ -58,7 +58,10 @@
                     },
                     "script_score": {
                         "lang": "groovy",
-                        "script": "(doc[\"score.final\"].value * 1) * (_score * 0.3)"
+                        "script": "(doc[\"score.final\"].value * 1) * (_score * 0.3) + doc[\"package.name.raw\"].value.equals(text) ? 100000 : 0",
+                        "params":  {
+                          "text": "sass"
+                        }
                     }
                 }
             }

--- a/test/fixtures/search-suggestions-sass.json
+++ b/test/fixtures/search-suggestions-sass.json
@@ -58,10 +58,7 @@
                     },
                     "script_score": {
                         "lang": "groovy",
-                        "script": "doc[\"package.name.raw\"].value.equals(text) ? 100000 + _score : _score",
-                        "params": {
-                            "text": "sass"
-                        }
+                        "script": "(doc[\"score.final\"].value * 1) * (_score * 0.3)"
                     }
                 }
             }


### PR DESCRIPTION
Introduces the same `analyzerWeight` and `scoreWeight` toggles available when performing a similarity search.

TODO:

- [x] update docs.

CC: @aearly